### PR TITLE
feat: Implement PUT and DELETE endpoints for task management

### DIFF
--- a/kadai5_go-echo-try/main.go
+++ b/kadai5_go-echo-try/main.go
@@ -96,5 +96,75 @@ func main() {
 		})
 	})
 
+	e.PUT("/tasks/:id", func(c echo.Context) error {
+		idParam := c.Param("id")
+		id, err := strconv.Atoi(idParam)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{
+				"message": "Invalid task ID",
+				"error":   err.Error(),
+			})
+		}
+
+		updateTask := new(Task)
+		if err := c.Bind(updateTask); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{
+				"message": "Invalid request body",
+				"error":   err.Error(),
+			})
+		}
+		if updateTask.Name == "" {
+			return c.JSON(http.StatusBadRequest, map[string]string{
+				"message": "Task name cannot be empty",
+			})
+		}
+
+		taskIndex := -1
+		for i, task := range tasks {
+			if task.ID == id {
+				taskIndex = i
+				break
+			}
+		}
+
+		if taskIndex == -1 {
+			return c.JSON(http.StatusNotFound, map[string]string{
+				"message": "Task not found",
+			})
+		}
+
+		tasks[taskIndex].Name = updateTask.Name
+		tasks[taskIndex].Status = updateTask.Status
+
+		return c.JSON(http.StatusOK, tasks[taskIndex])
+	})
+
+	e.DELETE("/tasks/:id", func(c echo.Context) error {
+		idParam := c.Param("id")
+		id, err := strconv.Atoi(idParam)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{
+				"message": "Invalid task ID",
+				"error":   err.Error(),
+			})
+		}
+
+		taskIndex := -1
+		for i, task := range tasks {
+			if task.ID == id {
+				taskIndex = i
+				break
+			}
+		}
+		if taskIndex == -1 {
+			return c.JSON(http.StatusNotFound, map[string]string{
+				"message": "Task not found",
+			})
+		}
+
+		tasks = append(tasks[:taskIndex], tasks[taskIndex+1:]...)
+		return c.NoContent(http.StatusNoContent)
+	})
+
 	e.Logger.Fatal(e.Start(":1323"))
 }

--- a/kadai5_go-echo-try/main.go
+++ b/kadai5_go-echo-try/main.go
@@ -3,21 +3,26 @@ package main
 import (
 	"net/http"
 
+	"strconv"
 	"strings"
 
 	"github.com/labstack/echo/v4"
 )
 
 type Task struct {
+	ID     int    `json:"id"`
 	Name   string `json:"name"`
 	Status string `json:"status"`
 }
 
-var tasks = []Task{
-	{Name: "ご飯食べる", Status: "完了"},
-	{Name: "家に帰る", Status: "未着手"},
-	{Name: "寝る", Status: "未着手"},
-}
+var (
+	tasks = []Task{
+		{ID: 1, Name: "ご飯食べる", Status: "完了"},
+		{ID: 2, Name: "家に帰る", Status: "未着手"},
+		{ID: 3, Name: "寝る", Status: "未着手"},
+	}
+	taskIDCounter = len(tasks)
+)
 
 func main() {
 	e := echo.New()
@@ -42,6 +47,53 @@ func main() {
 		}
 
 		return c.JSON(http.StatusOK, filteredTasks)
+	})
+
+	// POST /tasks エンドポイント: 新しいタスクを追加
+	e.POST("/tasks", func(c echo.Context) error {
+		newTask := new(Task)
+
+		if err := c.Bind(newTask); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{
+				"message": "Invalid request body",
+				"error":   err.Error(),
+			})
+		}
+
+		if newTask.Name == "" {
+			return c.JSON(http.StatusBadRequest, map[string]string{
+				"message": "Task name cannot be empty",
+			})
+		}
+
+		taskIDCounter++
+		newTask.ID = taskIDCounter
+
+		tasks = append(tasks, *newTask)
+
+		return c.JSON(http.StatusCreated, newTask)
+	})
+
+	// GET /tasks/:id エンドポイント: 特定のタスクを取得
+	e.GET("/tasks/:id", func(c echo.Context) error {
+		idParam := c.Param("id")
+		id, err := strconv.Atoi(idParam)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{
+				"message": "Invalid task ID",
+				"error":   err.Error(),
+			})
+		}
+
+		for _, task := range tasks {
+			if task.ID == id {
+				return c.JSON(http.StatusOK, task)
+			}
+		}
+
+		return c.JSON(http.StatusNotFound, map[string]string{
+			"message": "Task not found",
+		})
 	})
 
 	e.Logger.Fatal(e.Start(":1323"))


### PR DESCRIPTION
## 概要

タスク管理APIに更新(PUT)と削除(DELETE)の機能を追加しました。
これにより、CRUD (Create, Read, Update, Delete) 操作の基本的なバックエンドAPIが全て完成しました。

## 実装内容

### 1. `PUT /tasks/:id` (タスクの更新)
- 指定されたIDのタスクについて、名前(`name`)とステータス(`status`)を更新します。
- **IDの扱い**: URLパスのID (`:id`) を唯一の権威ある識別子とし、リクエストボディに含まれるIDは無視する実装としました。（IDの不変性とAPIの整合性を考慮）
- **バリデーション**:
    - URLパスのIDが不正な場合は `400 Bad Request` を返します。
    - リクエストボディが不正な場合は `400 Bad Request` を返します。
    - タスク名が空の場合は `400 Bad Request` を返します。
- **エラーハンドリング**:
    - 指定されたIDのタスクが見つからない場合は `404 Not Found` を返します。
- **レスポンス**: 成功時には `200 OK` と、更新後のタスクの最新の状態を返します。

### 2. `DELETE /tasks/:id` (タスクの削除)
- 指定されたIDのタスクをリストから削除します。
- **削除ロジック**: Goのスライス操作のイディオム（`append` を使った結合）を用いて、指定インデックスの要素を削除します。
- **エラーハンドリング**:
    - URLパスのIDが不正な場合は `400 Bad Request` を返します。
    - 指定されたIDのタスクが見つからない場合は `404 Not Found` を返します。
- **レスポンス**: 成功時には `204 No Content` を返し、レスポンスボディは空とします。（APIの標準的な作法に従う）

## Postmanでの動作確認

以下のエンドポイントで動作確認済みです。

- **PUT /tasks/1 (例)**
    - Request Body: `{"name": "更新されたタスク名", "status": "完了"}`
    - Response: `200 OK` と更新されたタスクデータ
- **DELETE /tasks/1 (例)**
    - Response: `204 No Content`
    - その後 `GET /tasks` でリストからタスクが削除されていることを確認
